### PR TITLE
fix(number_formatter): avoid floating point precision errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed:
+- Ensure that large numbers do not change due to rounding when formatted
+
 ## [1.0.1] - 2018-05-06
 ### Fixed:
 - Ensure non-numeric strings are ignored without any errors

--- a/number_formatter.py
+++ b/number_formatter.py
@@ -100,19 +100,32 @@ class FormatNumberCommand(sublime_plugin.TextCommand):
         new_string = substr.replace(thousands_separator, "")
 
       else:
+        decimal_number = ""
+
         # Adds formatting to the number
         if bool(re.search(re.escape(decimal_separator) + '\d', substr)):
-          number = float(substr.replace(decimal_separator, "."))
+          # Splits the number into whole and decimal number strings
+          whole_number, decimal_number = substr.split(decimal_separator)
 
         else:
-          number = int(substr)
+          whole_number = substr
 
         # Skips formatting four-digit numbers when set
-        if (not format_thousands) and (1000 <= number <= 9999):
+        if (not format_thousands) and (1000 <= int(whole_number) <= 9999):
           continue
 
-        new_string = "{:,}".format(number) \
-                           .replace(",", thousands_separator) \
-                           .replace(".", decimal_separator)
+        new_string = ""
+
+        # Decorates whole number strings by adding a comma to every third
+        # character starting from the end:
+        for idx, character in enumerate(reversed(whole_number)):
+          if idx % 3 == 0 and idx > 0:
+            character = character + thousands_separator
+
+          new_string = character + new_string
+
+        # Recombines the whole and decimal number strings into a single number
+        if len(decimal_number) > 0:
+          new_string += decimal_separator + decimal_number
 
       self.view.replace(edit, region, new_string)


### PR DESCRIPTION
This commit formats the string of numbers by adding the thousands
separator to every third character from the end of each whole number.

The fundamental way by which Python handles floating point arithmetics
(https://docs.python.org/3/library/decimal.html) causes precision errors
on larger numbers (e.g., `9999999999.9999999999`). Hence, the changes in
this commit avoid using `float()` and `int()` functions for creating and
formatting the actual output strings. Note that both of those functions
are still used for verification and control proposes: when evaluating
whether the string is a number and when comparing it to other numbers.

#5