### PR TITLE
fix(number_formatter): skips formatting empty regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed:
 - Ensure that large numbers do not change due to rounding when formatted
+- Ensure that empty selected regions do not throw an error in the console
 
 ## [1.0.1] - 2018-05-06
 ### Fixed:

--- a/number_formatter.py
+++ b/number_formatter.py
@@ -88,6 +88,9 @@ class FormatNumberCommand(sublime_plugin.TextCommand):
     for region in selected_regions:
       expanded_region = self.expand_region_to_whitespace(region)
 
+      if expanded_region is None:
+        continue
+
       if self.is_number(self.view.substr(expanded_region)):
         expanded_regions.append(expanded_region)
 


### PR DESCRIPTION
Attempting to format an empty region such as a blank line would throw a
`TypeError` because it trying to combine `None` with an integer within
the `sublime.View.substr()` command.

This commit fixes the issue by preemptively ignoring blank lines.

fixes #9