### PR TITLE
fix(number_formatter): ignores useless decimal dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed:
 - Ensure that large numbers do not change due to rounding when formatted
 - Ensure that empty selected regions do not throw an error in the console
+- Ensure that a useless decimal dot (e.g., `1234.`) doesn't count as a digit
 
 ## [1.0.1] - 2018-05-06
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ To change the settings, simply edit the `NumberFormatter.sublime-settings` file 
 
 ## Warnings
 
-* Preceding zeros are stripped out: `000123` » `123`
-* Trailing decimal zeros are stripped out: `0.123000` » `0.123`
-* A missing leading zero is added to all decimal numbers: `.123` » `0.123`
+* Numbers with preceding zeros are formatted anyway (`000123` » `000,123`)
 * When the `thousands_separator` is set to an empty space (`" "`), the whole number must be selected in order to unformat it (`12 345` » `12345`)
 
 ## Changelog

--- a/number_formatter.py
+++ b/number_formatter.py
@@ -103,10 +103,10 @@ class FormatNumberCommand(sublime_plugin.TextCommand):
         new_string = substr.replace(thousands_separator, "")
 
       else:
-        decimal_number = ""
+        decimal_number = None
 
         # Adds formatting to the number
-        if bool(re.search(re.escape(decimal_separator) + '\d', substr)):
+        if bool(re.search(re.escape(decimal_separator), substr)):
           # Splits the number into whole and decimal number strings
           whole_number, decimal_number = substr.split(decimal_separator)
 
@@ -128,7 +128,7 @@ class FormatNumberCommand(sublime_plugin.TextCommand):
           new_string = character + new_string
 
         # Recombines the whole and decimal number strings into a single number
-        if len(decimal_number) > 0:
+        if decimal_number is not None:
           new_string += decimal_separator + decimal_number
 
       self.view.replace(edit, region, new_string)


### PR DESCRIPTION
This commit fixes an issue where a useless decimal dot (e.g., `1234.`)
would count as a digit and affect the formatting by ignoring it.

The newly updated `README.md` also reflects fewer and newer caveats.

fixes #11