### PR TITLE
docs(README): add installation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added:
+- Installation instructions to the `README`
+
+### Fixed:
+- Ensure that the repository name is addressed in the `CONTRIBUTING` guide
+
 ## [1.0.3] - 2018-05-14
 ### Fixed:
 - Ensure that updating the settings take immediate effect

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,22 +15,22 @@ This project is currently being maintained by:
 
 ## Order of Operations
 
-1. [Create a new issue](https://github.com/ilyakam/RENAMEME/issues/new)
+1. [Create a new issue](https://github.com/ilyakam/NumberFormatter/issues/new)
 1. Fork the repo
 1. Write code and thoroughly test it
-1. [Submit a pull request](https://github.com/ilyakam/RENAMEME/compare) against `develop`
+1. [Submit a pull request](https://github.com/ilyakam/NumberFormatter/compare) against `develop`
 1. Communicate in a timely manner while the PR is open
 
 ## Getting Started
 1. Clone this repo (`~/code` is assumed)
    ```sh
    cd ~/code
-   git clone git@github.com:ilyakam/RENAMEME.git
+   git clone git@github.com:ilyakam/NumberFormatter.git
    ```
 1. Create an alias in your [Sublime Text's Packages folder](https://forum.sublimetext.com/t/9484) (macOS is assumed)
    ```sh
    cd ~/Library/Application\ Support/Sublime\ Text\ 3/Packages/
-   ln -s ~/code/RENAMEME ./
+   ln -s ~/code/NumberFormatter ./
    ```
 
 ## Commit Guidelines

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 This [Sublime Text](http://www.sublimetext.com/) plugin formats plain numbers by adding a thousands separator to them. It also unformats them in reverse. See the [Features](#features) section below for details.
 
+## Installation
+
+* **Package Control**
+  1. [Install Package Control](https://packagecontrol.io/installation)
+  1. [Bring up the Command Palette](https://sublime-text.readthedocs.io/en/stable/reference/command_palette.html#how-to-use-the-command-palette) and type "Package Control: Install Package"
+  1. Type "NumberFormatter" and press <kbd>enter</kbd>
+* **Directly**
+  1. Locate the `Packages` folder in the [data directory](http://docs.sublimetext.info/en/sublime-text-3/basic_concepts.html#the-data-directory)
+  1. Download the [latest version of NumberFormatter](https://github.com/ilyakam/NumberFormatter/releases/latest)
+  1. Extract the archive into the `Packages` folder
+* **Development**
+  1. [Follow the instructions on the `CONTRIBUTING` guide](./CONTRIBUTING.md#getting-started)
+
 ## Usage
 
 * Linux: <kbd>ctrl</kbd><kbd>shift</kbd><kbd>comma</kbd>


### PR DESCRIPTION
Add installation instructions to the `README` so that users can install
the plugin in different ways. Also update the `CONTRIBUTING` guide to
make sure that it's pointing to the correct repository.

closes #4