### PR TITLE
feat(number_formatter): add command to the Command Palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added:
 - Installation instructions to the `README`
+- Command to "Format Numbers" to the Command Palette
 
 ### Fixed:
 - Ensure that the repository name is addressed in the `CONTRIBUTING` guide

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,3 @@
+[
+  { "caption": "Format Numbers", "command": "format_number" }
+]


### PR DESCRIPTION
This commit adds a `.sublime-commands` file in order to add the "Format
Numbers" command right onto the Sublime Text Command Palette.

fixes #17